### PR TITLE
Fix: error handling in pdraw_vsink_get_frame

### DIFF
--- a/libpdraw-vsink/src/pdraw_vsink.c
+++ b/libpdraw-vsink/src/pdraw_vsink.c
@@ -568,7 +568,7 @@ int pdraw_vsink_get_frame(struct pdraw_vsink *self,
 			in_frame, &buf, &len);
 		if (res == -EPROTO) {
 			/* Frame is not packed but we have len, nothing to do */
-		} else if (res <= 0) {
+		} else if (res < 0) {
 			ULOG_ERRNO("mbuf_raw_video_frame_get_packed_buffer",
 				   -res);
 			goto out;


### PR DESCRIPTION
In `pdraw_vsink_get_frame`, change ( res <= 0) to (res < 0) when checking return code of `mbuf_raw_video_frame_get_packed_buffer` from the `libmedia-buffers` library https://github.com/Parrot-Developers/libmedia-buffers/blob/master/src/mbuf_raw_video_frame.c#L417-L426

`res == 0` is actually a success code (as is the convention elsewhere in the project) so should not be treated as an error which bails out from the function.

This bug was discovered while trying to pull video from an Anafi.